### PR TITLE
Refactor assistant code into modules

### DIFF
--- a/ai_assistant_llm_indexing.py
+++ b/ai_assistant_llm_indexing.py
@@ -1,0 +1,6 @@
+"""Backward-compatible entry point for the indexing demo."""
+
+from main import main
+
+if __name__ == "__main__":
+    main()

--- a/main.py
+++ b/main.py
@@ -1,0 +1,49 @@
+"""Example entry point that ties all helpers together."""
+
+import os
+import getpass
+
+from prompt_utils import messages_to_prompt, completion_to_prompt
+from model_setup import authenticate, load_llm, setup_service_context, build_index
+from query_utils import classify_query
+
+
+def main():
+    hf_token = getpass.getpass("Вставьте ваш токен: ")
+    openai_key = getpass.getpass("Введите OpenAI API Key:")
+    authenticate(hf_token, openai_key)
+
+    llm = load_llm()
+    setup_service_context(llm)
+
+    data_path = os.environ.get("DATA_PATH", "/kaggle/input/tanebaum-ostin")
+    index = build_index(data_path)
+
+    query = (
+        "Серверы работают под управлением каких операционных систем? "
+        "Поддерживаются ли UNIX и Windows?"
+    )
+    validation = classify_query(query)
+    if validation != "Запрос корректный.":
+        print(validation)
+        return
+
+    query_engine = index.as_query_engine(similarity_top_k=10)
+    response = query_engine.query(query)
+
+    message_template = f"""<s>system
+Ты являешься моделью, которая отвечает только на основании предоставленных источников.
+Отвечай строго на основе информации из текста.
+Если нужной информации нет в источнике, ответь: 'я не знаю'. Не добавляй ничего, что не указано в тексте. Не придумывай и не добавляй лишние данные.
+</s>
+<s>user
+Вопрос: {query}
+Источник:
+</s>
+"""
+    print("\nОтвет:")
+    print(response.response)
+
+
+if __name__ == "__main__":
+    main()

--- a/model_setup.py
+++ b/model_setup.py
@@ -1,0 +1,91 @@
+"""Model and index configuration helpers."""
+
+import os
+import torch
+from huggingface_hub import login
+from peft import PeftModel, PeftConfig
+from transformers import (
+    AutoModelForCausalLM,
+    AutoTokenizer,
+    BitsAndBytesConfig,
+    GenerationConfig,
+)
+from llama_index.core import SimpleDirectoryReader, Document, GPTVectorStoreIndex, Settings
+from llama_index.llms.huggingface import HuggingFaceLLM
+from llama_index.embeddings.langchain import LangchainEmbedding
+from langchain_huggingface import HuggingFaceEmbeddings
+
+from preprocess import preprocess_document
+
+
+def authenticate(hf_token: str, openai_key: str) -> None:
+    """Authenticate with HuggingFace and set the OpenAI key."""
+    login(hf_token, add_to_git_credential=True)
+    os.environ["OPENAI_API_KEY"] = openai_key
+
+
+def load_llm(model_name: str = "IlyaGusev/saiga_mistral_7b") -> HuggingFaceLLM:
+    """Load Saiga model with quantization and LoRA weights."""
+    quant_config = BitsAndBytesConfig(
+        load_in_4bit=True,
+        bnb_4bit_compute_dtype=torch.float16,
+        bnb_4bit_quant_type="nf4",
+        bnb_4bit_use_double_quant=True,
+    )
+
+    config = PeftConfig.from_pretrained(model_name)
+    base_model = AutoModelForCausalLM.from_pretrained(
+        config.base_model_name_or_path,
+        quantization_config=quant_config,
+        torch_dtype=torch.float16,
+        device_map="auto",
+    )
+
+    model = PeftModel.from_pretrained(base_model, model_name, torch_dtype=torch.float16)
+    model.eval()
+    tokenizer = AutoTokenizer.from_pretrained(model_name, use_fast=False)
+    generation_config = GenerationConfig.from_pretrained(model_name)
+
+    return HuggingFaceLLM(
+        model=model,
+        model_name=model_name,
+        tokenizer=tokenizer,
+        max_new_tokens=generation_config.max_new_tokens,
+        model_kwargs={"quantization_config": quant_config},
+        generate_kwargs={
+            "bos_token_id": generation_config.bos_token_id,
+            "eos_token_id": generation_config.eos_token_id,
+            "pad_token_id": generation_config.pad_token_id,
+            "no_repeat_ngram_size": generation_config.no_repeat_ngram_size,
+            "repetition_penalty": generation_config.repetition_penalty,
+            "temperature": generation_config.temperature,
+            "do_sample": True,
+            "top_k": 50,
+            "top_p": 0.95,
+        },
+        device_map="auto",
+    )
+
+
+def setup_service_context(llm: HuggingFaceLLM) -> None:
+    """Configure LlamaIndex global settings for the provided LLM."""
+    embed_model = LangchainEmbedding(
+        HuggingFaceEmbeddings(
+            model_name="sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"
+        )
+    )
+
+    Settings.llm = llm
+    Settings.embed_model = embed_model
+    Settings.chunk_size = 512
+
+
+def build_index(data_path: str) -> GPTVectorStoreIndex:
+    """Load and preprocess documents, then build a vector index."""
+    documents = [
+        preprocess_document(doc)
+        for doc in SimpleDirectoryReader(data_path).load_data()
+        if doc
+    ]
+    documents = [doc for doc in documents if doc is not None]
+    return GPTVectorStoreIndex.from_documents(documents)

--- a/preprocess.py
+++ b/preprocess.py
@@ -1,0 +1,31 @@
+"""Document preprocessing utilities."""
+
+import re
+import pandas as pd
+from llama_index.core import Document
+
+
+def extract_structured_data(text: str):
+    """Extract simple table-like structures from text."""
+    tables = []
+    table_pattern = re.compile(r"(\d+(?:\.\d+)?(?:\s+|,|\t)\d+(?:\.\d+)?(?:\s+|,|\t)\d+(?:\.\d+)?(?:\s+|,|\t)\d+)")
+    for match in table_pattern.finditer(text):
+        table_data = match.group(0)
+        columns = re.split(r"\s+|,|\t", table_data)
+        tables.append(columns)
+
+    if tables:
+        return pd.DataFrame(tables)
+    return None
+
+
+def preprocess_document(doc: Document):
+    """Filter and enrich documents for indexing."""
+    if len(doc.text) < 100:
+        return None
+
+    structured_data = extract_structured_data(doc.text)
+    if isinstance(structured_data, pd.DataFrame):
+        structured_data = structured_data.to_dict(orient="list")
+
+    return Document(text=doc.text, metadata={"structured_data": structured_data})

--- a/prompt_utils.py
+++ b/prompt_utils.py
@@ -1,0 +1,21 @@
+# Utilities for converting between message formats and prompts.
+
+def messages_to_prompt(messages):
+    """Convert structured messages to the prompt format expected by Saiga."""
+    prompt = ""
+    for message in messages:
+        if message.role == "system":
+            prompt += f"<s>system\n{message.content}</s>\n"
+        elif message.role == "user":
+            prompt += f"<s>user\n{message.content}</s>\n"
+        elif message.role == "bot":
+            prompt += f"<s>bot\n{message.content}</s>\n"
+    if not prompt.startswith("<s>system\n"):
+        prompt = "<s>system\n</s>\n" + prompt
+    prompt += "<s>bot\n"
+    return prompt
+
+
+def completion_to_prompt(completion: str) -> str:
+    """Format a single completion string to the model prompt."""
+    return f"<s>system\n</s>\n<s>user\n{completion}</s>\n<s>bot\n"

--- a/query_utils.py
+++ b/query_utils.py
@@ -1,0 +1,13 @@
+"""Query handling helpers."""
+
+
+def classify_query(query: str, min_length: int = 10, max_length: int = 100) -> str:
+    """Return a message describing whether the query length is acceptable."""
+    query = query.strip()
+    if not query:
+        return "Запрос пуст."
+    if len(query) < min_length:
+        return f"Запрос слишком короткий. Длина запроса: {len(query)} символов."
+    if len(query) > max_length:
+        return f"Запрос слишком длинный. Длина запроса: {len(query)} символов."
+    return "Запрос корректный."


### PR DESCRIPTION
## Summary
- split monolithic script into reusable helper modules
- add `main.py` as an example entry point
- keep a thin `ai_assistant_llm_indexing.py` wrapper for compatibility

## Testing
- `python -m py_compile prompt_utils.py preprocess.py query_utils.py model_setup.py main.py ai_assistant_llm_indexing.py`

------
https://chatgpt.com/codex/tasks/task_e_687f8f95f34c8320bfb5f37c17bc17c4